### PR TITLE
fix: Use a different replacement function in bump-version

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,4 +10,10 @@ NEW_VERSION="${2}"
 echo "Current version: ${OLD_VERSION}"
 echo "Bumping version: ${NEW_VERSION}"
 
-perl -pi -e "s/^version = \".*?\"/version = \"$NEW_VERSION\"/" Cargo.toml
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+replace "^version = \".*?\"" "version = \"$NEW_VERSION\"" Cargo.toml


### PR DESCRIPTION
I have seen this function being used in every other script, let's use it
here as well.
