### PR TITLE
fix: property removal is a breaking change if additionalProperties is false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl ChangeKind {
             Self::PropertyRemove {
                 lhs_additional_properties,
                 ..
-            } => *lhs_additional_properties,
+            } => !*lhs_additional_properties,
         }
     }
 }


### PR DESCRIPTION
See broken output in https://github.com/getsentry/sentry-kafka-schemas/pull/72
