### PR TITLE
fix: Add another failing test and fix licensing metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Diff changes between JSON schema files."
 repository = "https://github.com/getsentry/json-schema-diff"
+authors = ["Sentry <oss@sentry.io>"]
 
 [lib]
 name = "json_schema_diff"

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ assert_eq!(
 
 ## License
 
-Licensed under Apache 2.0, see `./LICENSE`
+Licensed under Apache 2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,4 +891,41 @@ mod tests {
         ]
         "###);
     }
+
+    #[test]
+    #[ignore]
+    fn add_property_in_array() {
+        let lhs = json! {{
+            "type": "array",
+            "items": [
+                {"const": "start_unmerge"},
+                {"$ref": "#/definitions/Hello"}
+            ],
+            "definitions": {
+                "Hello": {
+                    "type": "object",
+                }
+            }
+        }};
+
+        let rhs = json! {{
+            "type": "array",
+            "items": [
+                {"const": "start_unmerge"},
+                {"$ref": "#/definitions/Hello"}
+            ],
+            "definitions": {
+                "Hello": {
+                    "type": "object",
+                    "properties": {"transaction_id": {"type": "string"}}
+                }
+            }
+        }};
+
+        let diff = diff(lhs, rhs).unwrap();
+
+        // TODO: buggy wrt array references. suggest to get rid of jsonref crate dependency, and
+        // rewrite crate on top of schemars::schema::Schema
+        assert_debug_snapshot!(diff, @"");
+    }
 }


### PR DESCRIPTION
I tried some things to fix this bug with definitions, including
vendoring jsonref crate (which caused me to look at licensing of this
crate), but gave up for now.
