### PR TITLE
fix: Reenable help output for json-schema-diff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/bin/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0.70", optional = true }
-clap = { version = "4.1.13", features = ["std", "derive"], default_features = false, optional = true }
-schemars = "0.8.12"
+clap = { version = "4.1.13", features = ["std", "derive", "usage", "help"], default_features = false, optional = true }
+schemars = { version = "0.8.12", default_features = false }
 serde = "1.0.158"
 serde_json = "1.0.94"
 thiserror = "1.0.40"


### PR DESCRIPTION
`--help` was broken the entire time.

Also disable features in schemars that we don't use.
