### PR TITLE
do not clone Schema, clone only when the inner struct is Bool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
-use schemars::schema::RootSchema;
+use schemars::schema::{RootSchema, Schema};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -27,8 +27,8 @@ pub fn diff(lhs: Value, rhs: Value) -> Result<Vec<Change>, Error> {
     );
     walker.diff(
         "",
-        &mut walker.lhs_root.schema.clone(),
-        &mut walker.rhs_root.schema.clone(),
+        &mut Schema::Object(walker.lhs_root.schema.clone()),
+        &mut Schema::Object(walker.rhs_root.schema.clone()),
     )?;
     Ok(changes)
 }


### PR DESCRIPTION
follow-up for https://github.com/getsentry/json-schema-diff/pull/32#discussion_r1196514057

Previously `DiffWalker::diff` would receive `SchemaObject` instead of `Schema`. When we want to call the method recursively, however, this interface forces us to clone the schema, as the type for child schemas (subschemas, properties and array items) is `Schema`, not `SchemaObject`. Cloning should be performed only on boolean schema, because it is ok to clone boolean schema which is small, but not `SchemaObject` because the object could be huge depending on the user input.