### PR TITLE
feat: support custom ids and $defs from draft 2020-12

### DIFF
--- a/src/diff_walker.rs
+++ b/src/diff_walker.rs
@@ -149,7 +149,8 @@ impl<F: FnMut(Change)> DiffWalker<F> {
         let lhs_additional_properties = lhs
             .object()
             .additional_properties
-            .as_ref().is_none_or(|x| x.clone().into_object().is_true());
+            .as_ref()
+            .is_none_or(|x| x.clone().into_object().is_true());
 
         for removed in lhs_props.difference(&rhs_props) {
             (self.cb)(Change {
@@ -536,7 +537,8 @@ impl JsonSchemaExt for SchemaObject {
         } else if self
             .subschemas()
             .not
-            .as_ref().is_some_and(|x| x.clone().into_object().is_true())
+            .as_ref()
+            .is_some_and(|x| x.clone().into_object().is_true())
         {
             InternalJsonSchemaType::Never
         } else {

--- a/src/diff_walker.rs
+++ b/src/diff_walker.rs
@@ -149,8 +149,7 @@ impl<F: FnMut(Change)> DiffWalker<F> {
         let lhs_additional_properties = lhs
             .object()
             .additional_properties
-            .as_ref()
-            .map_or(true, |x| x.clone().into_object().is_true());
+            .as_ref().is_none_or(|x| x.clone().into_object().is_true());
 
         for removed in lhs_props.difference(&rhs_props) {
             (self.cb)(Change {
@@ -537,8 +536,7 @@ impl JsonSchemaExt for SchemaObject {
         } else if self
             .subschemas()
             .not
-            .as_ref()
-            .map_or(false, |x| x.clone().into_object().is_true())
+            .as_ref().is_some_and(|x| x.clone().into_object().is_true())
         {
             InternalJsonSchemaType::Never
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 mod diff_walker;
+mod resolver;
 mod types;
 
 pub use types::*;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,147 @@
+use std::collections::BTreeMap;
+
+use schemars::schema::{RootSchema, Schema, SchemaObject};
+
+pub struct Resolver {
+    ref_lookup: BTreeMap<String, String>,
+}
+
+impl Resolver {
+    pub fn for_schema(root: &RootSchema) -> Self {
+        let mut ref_lookup = BTreeMap::new();
+
+        for (key, schema) in &root.definitions {
+            if let Some(id) = schema.get_schema_id() {
+                ref_lookup.insert(id.to_owned(), key.clone());
+            }
+
+            if let Some(root_id) = root.schema.get_schema_id() {
+                ref_lookup.insert(format!("{root_id}#/definitions/{key}"), key.clone());
+                ref_lookup.insert(format!("{root_id}#/$defs/{key}"), key.clone());
+            }
+
+            ref_lookup.insert(format!("#/definitions/{key}"), key.clone());
+            ref_lookup.insert(format!("#/$defs/{key}"), key.clone());
+        }
+
+        Self { ref_lookup }
+    }
+
+    /// Resolves a reference.
+    ///
+    /// `root` must be the same schema that was used to construct the resolver.
+    /// This is not checked.
+    pub fn resolve<'a>(&self, root: &'a RootSchema, reference: &str) -> Option<&'a Schema> {
+        let key = self.ref_lookup.get(reference)?;
+        root.definitions.get(key)
+    }
+}
+
+trait MayHaveSchemaId {
+    fn get_schema_id(&self) -> Option<&str>;
+}
+
+impl MayHaveSchemaId for SchemaObject {
+    fn get_schema_id(&self) -> Option<&str> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.id.as_ref())
+            .map(|id| id.as_str())
+    }
+}
+
+impl MayHaveSchemaId for Schema {
+    fn get_schema_id(&self) -> Option<&str> {
+        match self {
+            Schema::Object(schema_obj) => schema_obj.get_schema_id(),
+            Schema::Bool(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn draft7_definitions() {
+        let root: RootSchema = serde_json::from_str(
+            r#"{
+                "definitions": {
+                    "A": {}
+                }
+            }"#,
+        )
+        .unwrap();
+        let resolver = Resolver::for_schema(&root);
+
+        let resolved = resolver.resolve(&root, "#/definitions/A");
+        assert!(resolved.is_some());
+
+        let resolved = resolver.resolve(&root, "#/definitions/not-there");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn draft7_root_has_id() {
+        let root: RootSchema = serde_json::from_str(
+            r#"{
+                "$id": "urn:uuid:e773a2e8-d746-4dc6-9480-0bba5ff33504",
+                "definitions": {
+                    "A": {}
+                }
+            }"#,
+        )
+        .unwrap();
+        let resolver = Resolver::for_schema(&root);
+
+        let resolved = resolver.resolve(&root, "#/definitions/A");
+        assert!(resolved.is_some());
+        let resolved = resolver.resolve(
+            &root,
+            "urn:uuid:e773a2e8-d746-4dc6-9480-0bba5ff33504#/definitions/A",
+        );
+        assert!(resolved.is_some());
+    }
+
+    #[test]
+    fn draft7_definition_has_id() {
+        let root: RootSchema = serde_json::from_str(
+            r#"{
+                "definitions": {
+                    "A": {
+                        "$id": "some-id"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let resolver = Resolver::for_schema(&root);
+
+        let resolved = resolver.resolve(&root, "some-id");
+        assert!(resolved.is_some());
+        assert_eq!(resolved, resolver.resolve(&root, "#/definitions/A"))
+    }
+
+    #[test]
+    fn draft2020_12_defs() {
+        let root: RootSchema = serde_json::from_str(
+            r#"{
+                "$defs": {
+                    "A": {
+                        "$id": "some-id"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let resolver = Resolver::for_schema(&root);
+
+        let resolved = resolver.resolve(&root, "#/$defs/A");
+        assert!(resolved.is_some());
+        assert_eq!(resolved, resolver.resolve(&root, "some-id"));
+
+        let resolved = resolver.resolve(&root, "#/$defs/not-there");
+        assert!(resolved.is_none());
+    }
+}


### PR DESCRIPTION
For #43.

This pull request adds further functionality of resolving references relative to their base URI as set by the `$id` keyword. ([The "$id" keyword](https://json-schema.org/draft-07/draft-handrews-json-schema-01#id-keyword), in draft-07 and in [draft 2020-12](https://json-schema.org/draft/2020-12/json-schema-core#name-the-id-keyword)).

It also expands the existing support of `#/definitions/A` style references, with `#/$defs/A` style references as found in draft 2020-12. ([Schema Re-Use With "$defs"](https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs), in draft 2020-12).

Since the json-schema 2020-12 spec is quite large and complicated it would be easy to get carried away with supporting various cases, I instead tried to be rather pragmatic. As has been the case so far, only subschemas in `definitions` or `$defs` are able to be referenced and so only they have their `$id` processed.

---
There are some features of how URI references are relative that could be implemented but I've chosen not to for now.

For example, given this following schema 

    {
        "$id": "https://example.com/root.json",
        "$defs": {
            "B": {
                "$id": "other.json"
            }
        }
    }

We are not supporting
- `"$ref": "https://example.com/other.json"`
- nor `"$ref": "root.json"`

Both of which would be expected to resolve in a fully compliant implementation.

And with the following schema document

    {
        "$id": "https://example.com/root.json",
        "$defs": {
            "B": {
                "$id": "https://example.com/other.json"
            }
        }
    }

we are not supporting `"$ref": "other.json"`. 

---

Another caveat to point out is, due to how schemars loads `$defs` into `definitions`, it means that we treat `#/$defs/A` the same as `#/definitions/A`.
i.e. this schema is invalid but we'd still end up processing it
```
{
    "properties": {
        "hello": {"$ref": "#/definitions/A"}
    }
    "$defs": {
        "A": {"type": "string"}
    }
}
```

---
Looking forward to feedback and am happy to adapt if there's anything that not quite right or if you feel something is missing.