### PR TITLE
feat: Support format

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -107,6 +107,23 @@ pub enum ChangeKind {
         /// The property that is now required
         property: String,
     },
+    /// A format constraint has been added.
+    FormatAdd {
+        /// The format that was added.
+        added: String,
+    },
+    /// A format constraint has been removed.
+    FormatRemove {
+        /// The format that was removed.
+        removed: String,
+    },
+    /// A format constraint has been changed.
+    FormatChange {
+        /// The old format value.
+        old_format: String,
+        /// The new format value.
+        new_format: String,
+    },
 }
 
 impl ChangeKind {
@@ -150,6 +167,9 @@ impl ChangeKind {
             Self::TupleChange { .. } => true,
             Self::RequiredRemove { .. } => false,
             Self::RequiredAdd { .. } => true,
+            Self::FormatAdd { .. } => true,
+            Self::FormatRemove { .. } => false,
+            Self::FormatChange { .. } => true,
         }
     }
 }

--- a/tests/fixtures/format/format_add.json
+++ b/tests/fixtures/format/format_add.json
@@ -1,0 +1,4 @@
+{
+  "lhs": { "type": "string" },
+  "rhs": { "type": "string", "format": "email" }
+}

--- a/tests/fixtures/format/format_change.json
+++ b/tests/fixtures/format/format_change.json
@@ -1,0 +1,4 @@
+{
+  "lhs": { "type": "string", "format": "uuid" },
+  "rhs": { "type": "string", "format": "date-time" }
+}

--- a/tests/fixtures/format/format_remove.json
+++ b/tests/fixtures/format/format_remove.json
@@ -1,0 +1,4 @@
+{
+  "lhs": { "type": "string", "format": "uri" },
+  "rhs": { "type": "string" }
+}

--- a/tests/fixtures/format/format_unchanged.json
+++ b/tests/fixtures/format/format_unchanged.json
@@ -1,0 +1,4 @@
+{
+  "lhs": { "type": "string", "format": "date" },
+  "rhs": { "type": "string", "format": "date" }
+}

--- a/tests/snapshots/test__from_fixtures@format__format_add.json.snap
+++ b/tests/snapshots/test__from_fixtures@format__format_add.json.snap
@@ -1,0 +1,20 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    type: string
+  rhs:
+    format: email
+    type: string
+input_file: tests/fixtures/format/format_add.json
+---
+[
+    Change {
+        path: "",
+        change: FormatAdd {
+            added: "email",
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@format__format_change.json.snap
+++ b/tests/snapshots/test__from_fixtures@format__format_change.json.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    format: uuid
+    type: string
+  rhs:
+    format: date-time
+    type: string
+input_file: tests/fixtures/format/format_change.json
+---
+[
+    Change {
+        path: "",
+        change: FormatChange {
+            old_format: "uuid",
+            new_format: "date-time",
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@format__format_remove.json.snap
+++ b/tests/snapshots/test__from_fixtures@format__format_remove.json.snap
@@ -1,0 +1,20 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    format: uri
+    type: string
+  rhs:
+    type: string
+input_file: tests/fixtures/format/format_remove.json
+---
+[
+    Change {
+        path: "",
+        change: FormatRemove {
+            removed: "uri",
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@format__format_unchanged.json.snap
+++ b/tests/snapshots/test__from_fixtures@format__format_unchanged.json.snap
@@ -1,0 +1,14 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    format: date
+    type: string
+  rhs:
+    format: date
+    type: string
+input_file: tests/fixtures/format/format_unchanged.json
+---
+[]


### PR DESCRIPTION
Adds support for the `format` validation keyword.

Additions of, and changes to, `format`s are considered breaking. Removals are not breaking.

Partially satisfies #23 