### PR TITLE
feat: Add enum support with context-aware breaking change detection

### DIFF
--- a/src/diff_walker.rs
+++ b/src/diff_walker.rs
@@ -417,6 +417,9 @@ impl<F: FnMut(Change)> DiffWalker<F> {
                     },
                 });
             }
+        }
+    }
+
     fn diff_pattern(&mut self, json_path: &str, lhs: &mut SchemaObject, rhs: &mut SchemaObject) {
         let lhs_pattern = &lhs.string().pattern;
         let rhs_pattern = &rhs.string().pattern;

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,6 +139,7 @@ pub enum ChangeKind {
         /// Whether the entire enum constraint was removed (rhs has no enum).
         /// If true, this is non-breaking as it relaxes the constraint.
         rhs_has_no_enum: bool,
+    },
     /// A pattern constraint has been added.
     PatternAdd {
         /// The pattern that was added.
@@ -238,10 +239,14 @@ impl ChangeKind {
             Self::FormatChange { .. } => true,
             // EnumAdd is breaking only if it adds a new enum constraint (lhs had no enum).
             // Adding values to an existing enum is non-breaking (accepts more data).
-            Self::EnumAdd { lhs_has_no_enum, .. } => *lhs_has_no_enum,
+            Self::EnumAdd {
+                lhs_has_no_enum, ..
+            } => *lhs_has_no_enum,
             // EnumRemove is breaking if removing values from a surviving enum constraint.
             // Removing the entire enum constraint is non-breaking (accepts more data).
-            Self::EnumRemove { rhs_has_no_enum, .. } => !rhs_has_no_enum,
+            Self::EnumRemove {
+                rhs_has_no_enum, ..
+            } => !rhs_has_no_enum,
             // Pattern changes are conservatively treated as breaking.
             // Determining if one regex is a subset of another requires complex analysis.
             Self::PatternAdd { .. } => true,

--- a/tests/fixtures/enum/add.json
+++ b/tests/fixtures/enum/add.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info", "debug"]
+  }
+}

--- a/tests/fixtures/enum/add_and_remove.json
+++ b/tests/fixtures/enum/add_and_remove.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["error", "warning", "debug"]
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["error", "info", "debug"]
+  }
+}

--- a/tests/fixtures/enum/add_constraint.json
+++ b/tests/fixtures/enum/add_constraint.json
@@ -1,0 +1,9 @@
+{
+  "lhs": {
+    "type": "string"
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  }
+}

--- a/tests/fixtures/enum/mixed_types.json
+++ b/tests/fixtures/enum/mixed_types.json
@@ -1,0 +1,8 @@
+{
+  "lhs": {
+    "enum": ["error", 1, null, true]
+  },
+  "rhs": {
+    "enum": ["error", 1, null, true, "warning"]
+  }
+}

--- a/tests/fixtures/enum/number_values.json
+++ b/tests/fixtures/enum/number_values.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "integer",
+    "enum": [1, 2, 3]
+  },
+  "rhs": {
+    "type": "integer",
+    "enum": [1, 2, 3, 4]
+  }
+}

--- a/tests/fixtures/enum/real_world_event_type.json
+++ b/tests/fixtures/enum/real_world_event_type.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["expectct", "expectstaple", "transaction", "default"]
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["expectct", "expectstaple", "transaction", "default", "generic"]
+  }
+}

--- a/tests/fixtures/enum/remove.json
+++ b/tests/fixtures/enum/remove.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info", "debug"]
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  }
+}

--- a/tests/fixtures/enum/remove_constraint.json
+++ b/tests/fixtures/enum/remove_constraint.json
@@ -1,0 +1,9 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  },
+  "rhs": {
+    "type": "string"
+  }
+}

--- a/tests/fixtures/enum/unchanged.json
+++ b/tests/fixtures/enum/unchanged.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  },
+  "rhs": {
+    "type": "string",
+    "enum": ["error", "warning", "info"]
+  }
+}

--- a/tests/snapshots/test__from_fixtures@enum__add.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__add.json.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+  rhs:
+    enum:
+      - error
+      - warning
+      - info
+      - debug
+    type: string
+input_file: tests/fixtures/enum/add.json
+---
+[
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("debug"),
+            lhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__add_and_remove.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__add_and_remove.json.snap
@@ -1,0 +1,35 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - warning
+      - debug
+    type: string
+  rhs:
+    enum:
+      - error
+      - info
+      - debug
+    type: string
+input_file: tests/fixtures/enum/add_and_remove.json
+---
+[
+    Change {
+        path: "",
+        change: EnumRemove {
+            removed: String("warning"),
+            rhs_has_no_enum: false,
+        },
+    },
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("info"),
+            lhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__add_constraint.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__add_constraint.json.snap
@@ -1,0 +1,38 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    type: string
+  rhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+input_file: tests/fixtures/enum/add_constraint.json
+---
+[
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("error"),
+            lhs_has_no_enum: true,
+        },
+    },
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("warning"),
+            lhs_has_no_enum: true,
+        },
+    },
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("info"),
+            lhs_has_no_enum: true,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__mixed_types.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__mixed_types.json.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - 1
+      - ~
+      - true
+  rhs:
+    enum:
+      - error
+      - 1
+      - ~
+      - true
+      - warning
+input_file: tests/fixtures/enum/mixed_types.json
+---
+[
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("warning"),
+            lhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__number_values.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__number_values.json.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - 1
+      - 2
+      - 3
+    type: integer
+  rhs:
+    enum:
+      - 1
+      - 2
+      - 3
+      - 4
+    type: integer
+input_file: tests/fixtures/enum/number_values.json
+---
+[
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: Number(4),
+            lhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__real_world_event_type.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__real_world_event_type.json.snap
@@ -1,0 +1,31 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - expectct
+      - expectstaple
+      - transaction
+      - default
+    type: string
+  rhs:
+    enum:
+      - expectct
+      - expectstaple
+      - transaction
+      - default
+      - generic
+    type: string
+input_file: tests/fixtures/enum/real_world_event_type.json
+---
+[
+    Change {
+        path: "",
+        change: EnumAdd {
+            added: String("generic"),
+            lhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__remove.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__remove.json.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - warning
+      - info
+      - debug
+    type: string
+  rhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+input_file: tests/fixtures/enum/remove.json
+---
+[
+    Change {
+        path: "",
+        change: EnumRemove {
+            removed: String("debug"),
+            rhs_has_no_enum: false,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__remove_constraint.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__remove_constraint.json.snap
@@ -1,0 +1,38 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+  rhs:
+    type: string
+input_file: tests/fixtures/enum/remove_constraint.json
+---
+[
+    Change {
+        path: "",
+        change: EnumRemove {
+            removed: String("error"),
+            rhs_has_no_enum: true,
+        },
+    },
+    Change {
+        path: "",
+        change: EnumRemove {
+            removed: String("warning"),
+            rhs_has_no_enum: true,
+        },
+    },
+    Change {
+        path: "",
+        change: EnumRemove {
+            removed: String("info"),
+            rhs_has_no_enum: true,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@enum__unchanged.json.snap
+++ b/tests/snapshots/test__from_fixtures@enum__unchanged.json.snap
@@ -1,0 +1,20 @@
+---
+source: tests/test.rs
+assertion_line: 12
+expression: diff
+info:
+  lhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+  rhs:
+    enum:
+      - error
+      - warning
+      - info
+    type: string
+input_file: tests/fixtures/enum/unchanged.json
+---
+[]


### PR DESCRIPTION
## Summary

Implements detection of JSON Schema `enum` changes with context-aware breaking change detection.

Resolves the issue where enum arrays being extended or reduced were not detected by the tool.

## Changes

- **Added `EnumAdd` and `EnumRemove` change types** with context flags (`lhs_has_no_enum` and `rhs_has_no_enum`)
- **Smart breaking change logic**:
  - Adding values to existing enum: **non-breaking** (accepts more data)
  - Removing values from existing enum: **breaking** (rejects previously valid data)  
  - Adding enum constraint entirely: **breaking** (restricts previously valid data)
  - Removing enum constraint entirely: **non-breaking** (accepts more data)
- **Comprehensive test coverage**: 9 test cases covering all scenarios including the real-world case from the issue

## Examples

```bash
# Adding a value to existing enum (non-breaking)
$ json-schema-diff old.json new.json
{"path":"","change":{"EnumAdd":{"added":"debug","lhs_has_no_enum":false}},"is_breaking":false}

# Removing a value from existing enum (breaking)
$ json-schema-diff old.json new.json  
{"path":"","change":{"EnumRemove":{"removed":"debug","rhs_has_no_enum":false}},"is_breaking":true}

# Adding enum constraint (breaking)
$ json-schema-diff old.json new.json
{"path":"","change":{"EnumAdd":{"added":"error","lhs_has_no_enum":true}},"is_breaking":true}

# Removing enum constraint (non-breaking)
$ json-schema-diff old.json new.json
{"path":"","change":{"EnumRemove":{"removed":"error","rhs_has_no_enum":true}},"is_breaking":false}
```

Fixes #38